### PR TITLE
update README to change default branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ## 🚀 安装和使用
 您需要克隆该仓库：
 ```bash
-$ git clone -b master --single-branch https://github.com/OpenBMB/CPM-Bee.git
+$ git clone -b main --single-branch https://github.com/OpenBMB/CPM-Bee.git
 ```
 并确保您的环境符合要求：
 ```bash

--- a/README_en.md
+++ b/README_en.md
@@ -40,7 +40,7 @@ Utilizing the Transformer auto-regressive architecture, CPM-Bee has been pre-tra
 ### Environment Setup
 Clone the CPM-Bee repository：
 ```bash
-$ git clone -b master --single-branch https://github.com/OpenBMB/CPM-Bee.git
+$ git clone -b main --single-branch https://github.com/OpenBMB/CPM-Bee.git
 ```
 Please ensure the environment to meet the following requirements:
 ```bash


### PR DESCRIPTION
The default github branch name is changing to main